### PR TITLE
Fix test specs.

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,11 +1,43 @@
 import { TestBed, async } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { ReactiveFormsModule } from '@angular/forms';
+
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        NoopAnimationsModule,
+        MatCardModule,
+        MatChipsModule,
+        MatDialogModule,
+        MatDividerModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatInputModule,
+        MatListModule,
+        MatMenuModule,
+        MatSidenavModule,
+        MatToolbarModule,
+        ReactiveFormsModule,
+      ],
       declarations: [
-        AppComponent
+        AppComponent,
       ],
     }).compileComponents();
   }));
@@ -22,10 +54,10 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('blast-off-with-am');
   });
 
-  it('should render title in a h1 tag', () => {
+  it('should render material toolbar title in a h1 tag', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to blast-off-with-am!');
+    expect(compiled.querySelector('h1').textContent).toEqual('Astronaut Directory');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import { AddAstronautComponent } from './add-astronaut/add-astronaut.component';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
+  title = 'blast-off-with-am';
   astronauts: Observable<Astronaut[]>;
   filterState: FilterState;
   filters: Observable<Filter[]>;

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>BlastOffWithAm</title>
+  <title>{{ title }}</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
A couple of Material module were required in the spec file `app.component.spec.ts`.

`app.component.ts` had no `title` attribute.
This made the the second test (`should have as title 'blast-off-with-am'`) fail.

The change in `index.html` is not really required, though; the tests run fine w/ and w/o it.